### PR TITLE
Fix incorrect Math.ceil usage

### DIFF
--- a/docs/ch4.md
+++ b/docs/ch4.md
@@ -137,7 +137,7 @@ System.out.println(position);  //-3
 ### floor & ceil
 ```java
 double floor = Math.floor(3.8); // 3.0
-double ceil = Math.ceil(3.8); // 8.0
+double ceil = Math.ceil(3.8); // 4.0
 ```
 
 ### round


### PR DESCRIPTION
Fix the incorrect usage of `Math.ceil()` in the code. The original code incorrectly suggested that `Math.ceil(3.8)` would return `8.0`. The correct behavior of `Math.ceil()` is to return `4.0`, which is the smallest integer greater than or equal to `3.8`.